### PR TITLE
Enable remaining schools and district-wide sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ didn't like that idea, so I added all this to my /etc/hosts file:
 192.168.33.2 bmms.schools.dev
 192.168.33.2 bpes.schools.dev
 192.168.33.2 bses.schools.dev
+192.168.33.2 bwes.schools.dev
 192.168.33.2 cces.schools.dev
 192.168.33.2 ces.schools.dev
 192.168.33.2 chs.schools.dev
@@ -66,6 +67,7 @@ didn't like that idea, so I added all this to my /etc/hosts file:
 192.168.33.2 ghs.schools.dev
 192.168.33.2 gms.schools.dev
 192.168.33.2 hc.schools.dev
+192.168.33.2 hcasc.schools.dev
 192.168.33.2 hcms.schools.dev
 192.168.33.2 hes.schools.dev
 192.168.33.2 hhs.schools.dev

--- a/ansible/vars/schools.yml
+++ b/ansible/vars/schools.yml
@@ -2,15 +2,18 @@
 school_shortnames:
   - aes
   - ahs
+  - arl
   - bbes
   - bbms
   - bmms
   - bpes
   - bses
+  - bwes
   - cces
   - ces
   - chs
   - cles
+  - cls
   - cms
   - cres
   - dles
@@ -27,6 +30,8 @@ school_shortnames:
   - ges
   - ghs
   - gms
+  - hc
+  - hcasc
   - hcms
   - hes
   - hhs
@@ -48,6 +53,7 @@ school_shortnames:
   - mwes
   - mwms
   - nes
+  - nto
   - omhs
   - omms
   - ples
@@ -58,6 +64,7 @@ school_shortnames:
   - res
   - rhhs
   - rhs
+  - sch
   - ses
   - sfes
   - sjles


### PR DESCRIPTION
Enable the remaining school and education center sites (ARL, BWES,
CLS, HC).  While our district-level content sites (HCASC, NTO, and
SCH) are updated infrequently, let's still make them available for
testing as well.